### PR TITLE
add ternary to data retrieval

### DIFF
--- a/twitter_data/build.sbt
+++ b/twitter_data/build.sbt
@@ -13,7 +13,8 @@ lazy val root = (project in file("."))
     // https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient
     libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.5.12",
     // https://mvnrepository.com/artifact/commons-io/commons-io
-    libraryDependencies += "commons-io" % "commons-io" % "2.8.0"
+    libraryDependencies += "commons-io" % "commons-io" % "2.8.0",
+    libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.427"
   )
 
 // See https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html for instructions on how to publish to Sonatype.

--- a/twitter_data/src/main/scala/com/revature/twitter_data/Runner.scala
+++ b/twitter_data/src/main/scala/com/revature/twitter_data/Runner.scala
@@ -1,5 +1,7 @@
 package twitter_data
 
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.auth.BasicAWSCredentials
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions
 import org.apache.spark.sql.DataFrameReader
@@ -8,7 +10,9 @@ import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.config.CookieSpecs
 import org.apache.http.client.utils.URIBuilder
 import org.apache.http.client.methods.HttpGet
+import org.apache.http.util.EntityUtils
 import java.io.BufferedReader
+import java.io.File
 import java.io.InputStreamReader
 import java.io.PrintWriter
 import java.nio.file.Files
@@ -32,28 +36,61 @@ object Runner {
   def helloTweetStream(spark: SparkSession): Unit = {
     import spark.implicits._
     val bearerToken = System.getenv(("TWITTER_BEARER_TOKEN"))
+    val tweetstreamURI = "https://api.twitter.com/2/tweets/sample/stream"
+    val userURI = "https://api.twitter.com/2/users"
+    val testUserIdString = "?ids=830480558597763075,150942805,1479694148,1284732561927929856,880545236732313600"
 
-    tweetStreamToDir(bearerToken, queryString = "?expansions=author_id")
+    // tweetStreamToDir(bearerToken, uriString = tweetstreamURI + "?expansions=author_id")
+    tweetStreamToDir(bearerToken, dirname = "users", uriString = userURI + testUserIdString + "&user.fields=created_at,verified")
   }
 
   def tweetStreamToDir(
       bearerToken: String,
       dirname: String = "twitterstream",
       linesPerFile: Int = 1000,
-      queryString: String = ""
+      uriString: String = ""
   ) = {
+
+    // AWS configs
+    val bucketName = "usf-210104-big-data"
+    val key = System.getenv(("DAS_KEY_ID"))
+    val secret = System.getenv(("DAS_SEC"))
+
+    // AWS client set up
+    val awsCredentials = new BasicAWSCredentials(key, secret)
+    val amazonS3Client = new AmazonS3Client(awsCredentials)
+
     val httpClient = HttpClients.custom
       .setDefaultRequestConfig(
         RequestConfig.custom.setCookieSpec(CookieSpecs.STANDARD).build()
       )
       .build()
     val uriBuilder: URIBuilder = new URIBuilder(
-      s"https://api.twitter.com/2/tweets/sample/stream$queryString"
+      uriString
     )
     val httpGet = new HttpGet(uriBuilder.build())
     httpGet.setHeader("Authorization", s"Bearer $bearerToken")
+
     val response = httpClient.execute(httpGet)
     val entity = response.getEntity()
+
+    if (dirname == "users")
+
+    if (null != entity) {
+      val userData = EntityUtils.toString(entity, "UTF-8")
+      var fileWriter = new PrintWriter(Paths.get("users.tmp").toFile)
+      fileWriter.write(userData)
+      fileWriter.flush()
+      fileWriter.close()
+
+      val millis = System.currentTimeMillis()
+      val folderName = s"$dirname/data-$millis"
+      var fileToUpload = new File("users.tmp")
+      amazonS3Client.putObject(bucketName, folderName, fileToUpload)
+    }
+
+    else
+
     if (null != entity) {
       val reader = new BufferedReader(
         new InputStreamReader(entity.getContent())
@@ -65,10 +102,13 @@ object Runner {
       while (line != null) {
         if (lineNumber % linesPerFile == 0) {
           fileWriter.close()
+          val fileName = s"$dirname/tweetstream-$millis-${lineNumber/linesPerFile}"
           Files.move(
             Paths.get("tweetstream.tmp"),
-            Paths.get(s"$dirname/tweetstream-$millis-${lineNumber/linesPerFile}"))
+            Paths.get(fileName))
           fileWriter = new PrintWriter(Paths.get("tweetstream.tmp").toFile)
+          var fileToUpload = new File(fileName)
+          amazonS3Client.putObject(bucketName, fileName, fileToUpload)
         }
 
         fileWriter.println(line)


### PR DESCRIPTION
### A Few Changes Here
- Added a ternary that way we can reuse the tweetStreamToDir function for streaming calls as well as user calls on the fly
> WARNING you will have to change how you call this function so that it includes either tweetstreamURI or userURI. There are examples on lines 43 and 44 
- Added packages to enable writing to AWS s3
- This code writes streamed data to local tweetstream.tmp and twitterstream like before but will also write the same files to s3

#### To Do
- Get IAM roles for team, this code will most likely fail if you run it locally without IAM roles
- Write example for how to read from s3